### PR TITLE
Fix etal() truncating hyphenated author names

### DIFF
--- a/toXiv_format.py
+++ b/toXiv_format.py
@@ -135,8 +135,9 @@ def surnames(orig):
 
 
 def etal(orig):
-    first_author = re.search(r"[\w|.| ]+,", orig)
-    return first_author.group() + " et al."
+    parts = orig.split(",", 1)
+    first_author = parts[0].strip()
+    return first_author + ", et al."
 
 
 # separate an abstract with a counter and url tag


### PR DESCRIPTION
The regex [\w|.| ]+, in etal() did not include hyphens. Replace the fragile regex with a simple comma split, which matches the comma-separated format produced by arXiv_feed_parser.

Same fix as so-okada/twXiv#2.

https://claude.ai/code/session_01TET7A7GKXPBbS3bmbY2pkG