### PR TITLE
Fix empty authors formatting and surnames() for single-word names

### DIFF
--- a/toXiv_format.py
+++ b/toXiv_format.py
@@ -129,7 +129,7 @@ def noparen(test_str):
 
 def surnames(orig):
     names = orig.split(",")
-    sr_names = [HumanName(one).last for one in names]
+    sr_names = [HumanName(one).last or one.strip() for one in names]
     separator = ", "
     return separator.join(sr_names)
 

--- a/toXiv_post.py
+++ b/toXiv_post.py
@@ -696,10 +696,10 @@ def newsubmissions(
     for each in entries:
         arxiv_id = each["id"]
         # each['abstract'] for instances with 5000 chars/toot
+        authors_part = ("\n\n" + each["authors"]) if each["authors"] else ""
         article_text = (
             each["title"]
-            + "\n\n"
-            + each["authors"]
+            + authors_part
             + "\n"
             + each["abs_url"]
             + " "
@@ -1056,8 +1056,9 @@ def grouped_replacements(
         authors = tXf.authors(authors, 100)
 
         arXiv_url = "https://arxiv.org/abs/" + arxiv_id
+        authors_line = "\n" + "  " + authors if authors else ""
         each_paper_chunk = (
-            "- " + title + "\n" + "  " + authors + "\n" + "  " + arXiv_url
+            "- " + title + authors_line + "\n" + "  " + arXiv_url
         )
 
         subject = each["primary_subject"]
@@ -1159,8 +1160,9 @@ def grouped_crosslists(
         authors = tXf.authors(authors, 100)
 
         arXiv_url = "https://arxiv.org/abs/" + arxiv_id
+        authors_line = "\n" + "  " + authors if authors else ""
         each_paper_chunk = (
-            "- " + title + "\n" + "  " + authors + "\n" + "  " + arXiv_url
+            "- " + title + authors_line + "\n" + "  " + arXiv_url
         )
 
         subject = each["primary_subject"]


### PR DESCRIPTION
When authors() returns "", the toot composition produced blank lines or lines with only whitespace. Now only include the authors portion when it is non-empty, across newsubmissions, grouped_replacements, and grouped_crosslists.

Also make surnames() fall back to the original name when HumanName returns an empty last name (e.g. for single-word names like "Aristotle").

Same fix as so-okada/twXiv#3.

https://claude.ai/code/session_01TET7A7GKXPBbS3bmbY2pkG